### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime
-
+import logging
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
 from firebase_admin import credentials, firestore, initialize_app, storage
@@ -11,7 +11,7 @@ from src.logic import analysing_audio
 
 # Load environment variables from a .env file
 load_dotenv()
-
+logging.basicConfig(level=logging.ERROR)
 # Initialize FastAPI app
 app = FastAPI()
 
@@ -115,7 +115,8 @@ async def test(request_body: RequestBody):
         os.remove(file_name)
         return {"result": analysis_result}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        logging.error("An error occurred: %s", str(e))
+        raise HTTPException(status_code=500, detail="An internal error has occurred.") from e
 
 
 # Function to check if necessary environment variables are set


### PR DESCRIPTION
Potential fix for [https://github.com/PamuduW/SayMore/security/code-scanning/1](https://github.com/PamuduW/SayMore/security/code-scanning/1)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the `test` function in `main.py` to log the exception and return a generic error message.

1. Import the `logging` module to log the detailed error message.
2. Modify the `except` block in the `test` function to log the exception and raise an `HTTPException` with a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
