### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-speech
 black
 ruff
 isort
+werkzeug==3.1.3


### PR DESCRIPTION
Potential fix for [https://github.com/PamuduW/SayMore/security/code-scanning/4](https://github.com/PamuduW/SayMore/security/code-scanning/4)

To fix the problem, we need to validate the `file_name` to ensure it does not contain any malicious paths or characters. We can achieve this by normalizing the path and ensuring it is within a specific directory. Additionally, we can use a library function like `werkzeug.utils.secure_filename` to sanitize the file name.

1. Normalize the `file_name` using `os.path.normpath` to remove any ".." segments.
2. Ensure the normalized path starts with a safe root directory.
3. Use `werkzeug.utils.secure_filename` to sanitize the file name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
