### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,6 +118,8 @@ async def test(request_body: RequestBody):
         # Clean up the downloaded file
         blob.delete()
         os.remove(full_path)
+        if "error" in analysis_result:
+            raise HTTPException(status_code=500, detail=analysis_result["error"])
         return {"result": analysis_result}
     except RuntimeError as e:
         logging.error("An error occurred: %s", str(e))

--- a/src/logic.py
+++ b/src/logic.py
@@ -23,4 +23,5 @@ def analysing_audio(file_name, test_type, lan_flag):
             analysis_result = stutter_test(file_name)
         return analysis_result
     except Exception as e:
-        raise RuntimeError("Error during audio analysis") from e
+        logging.error("Error during audio analysis: %s", str(e))
+        return {"error": "An error occurred during audio analysis."}


### PR DESCRIPTION
Potential fix for [https://github.com/PamuduW/SayMore/security/code-scanning/5](https://github.com/PamuduW/SayMore/security/code-scanning/5)

To fix the problem, we need to ensure that any error messages or stack traces are not included in the `analysis_result` returned to the user. Instead, we should log the error messages on the server and return a generic error message to the user.

1. Modify the `analysing_audio` function in `src/logic.py` to return a generic error message in case of an exception.
2. Update the `test` function in `main.py` to handle the generic error message appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
