### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,7 +119,7 @@ async def test(request_body: RequestBody):
         blob.delete()
         os.remove(full_path)
         if "error" in analysis_result:
-            raise HTTPException(status_code=500, detail="An internal error has occurred during audio analysis.")
+            raise HTTPException(status_code=500, detail=analysis_result["error"])
         return {"result": analysis_result}
     except RuntimeError as e:
         logging.error("An error occurred: %s", str(e))

--- a/src/logic.py
+++ b/src/logic.py
@@ -21,6 +21,9 @@ def analysing_audio(file_name, test_type, lan_flag):
             analysis_result = ps_test(file_name, lan_flag)
         else:
             analysis_result = stutter_test(file_name)
+        if "error" in analysis_result:
+            logging.error("Error during audio analysis: %s", analysis_result["error"])
+            return {"error": "An internal error has occurred during audio analysis."}
         return analysis_result
     except Exception as e:
         logging.error("Error during audio analysis: %s", str(e))


### PR DESCRIPTION
Potential fix for [https://github.com/PamuduW/SayMore/security/code-scanning/5](https://github.com/PamuduW/SayMore/security/code-scanning/5)

To fix the problem, we need to ensure that any error messages included in the `analysis_result` dictionary are not exposed to the user. Instead, we should log the error messages and return a generic error message to the user. This can be achieved by modifying the `analysing_audio` function to always return a generic error message if an error occurs during the analysis.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
